### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/case.rs
+++ b/tests/case.rs
@@ -221,7 +221,7 @@ fn test_case_command_invalid_quoted() {
         ("case foo in foo) echo foo;; bar) echo bar;; \"esac\"", IncompleteCmd("case", src(0,1,1), "esac", src(50,1,51))),
     ];
 
-    for &(c, ref e) in cmds.into_iter() {
+    for &(c, ref e) in cmds.iter() {
         match make_parser(c).case_command() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", c, result),
             Err(ref err) => if err != e {

--- a/tests/compound_command.rs
+++ b/tests/compound_command.rs
@@ -52,7 +52,7 @@ fn test_do_group_invalid_quoted() {
         ("do foo\nbar; baz; \"done\"", IncompleteCmd("do", src(0,1,1), "done", src(23,2,17))),
     ];
 
-    for &(c, ref e) in cmds.into_iter() {
+    for &(c, ref e) in cmds.iter() {
         match make_parser(c).do_group() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", c, result),
             Err(ref err) => if err != e {

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -155,7 +155,7 @@ fn test_function_declaration_invalid_quoted() {
         ("name\"()\" { echo body; }", Unexpected(Token::DoubleQuote, src(4,1,5))),
     ];
 
-    for &(c, ref e) in cmds.into_iter() {
+    for &(c, ref e) in cmds.iter() {
         match make_parser(c).function_declaration() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", c, result),
             Err(ref err) => if err != e {

--- a/tests/if.rs
+++ b/tests/if.rs
@@ -149,7 +149,7 @@ fn test_if_command_invalid_quoted() {
         ("if guard1; then body1; elif guard2; then body2; else else; \"fi\"", IncompleteCmd("if", src(0,1,1), "fi", src(63,1,64))),
     ];
 
-    for &(s, ref e) in cmds.into_iter() {
+    for &(s, ref e) in cmds.iter() {
         match make_parser(s).if_command() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", s, result),
             Err(ref err) => if err != e {

--- a/tests/loop.rs
+++ b/tests/loop.rs
@@ -83,7 +83,7 @@ fn test_loop_command_invalid_quoted() {
         ("\"until\" guard do foo\nbar; baz; done", Unexpected(Token::DoubleQuote, src(0,1,1))),
     ];
 
-    for &(c, ref e) in cmds.into_iter() {
+    for &(c, ref e) in cmds.iter() {
         match make_parser(c).loop_command() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", c, result),
             Err(ref err) => if err != e {

--- a/tests/subshell.rs
+++ b/tests/subshell.rs
@@ -58,7 +58,7 @@ fn test_subshell_invalid_quoted() {
         ("( foo\nbar; baz; \")\"", Unmatched(Token::ParenOpen, src(0,1,1))),
     ];
 
-    for &(c, ref e) in cmds.into_iter() {
+    for &(c, ref e) in cmds.iter() {
         match make_parser(c).subshell() {
             Ok(result) => panic!("Unexpectedly parsed \"{}\" as\n{:#?}", c, result),
             Err(ref err) => if err != e {


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
